### PR TITLE
HashMap with Fowler–Noll–Vo (more efficient for smaller hash keys)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme="README.md"
 
 [dependencies]
 rand = "0.4.2"
+fnv = "1.0.3"
 
 [dev-dependencies]
 criterion = "0.2"


### PR DESCRIPTION
This improves performance of the indexed mode